### PR TITLE
attempt to import GDAL b/c it is needed at the top of this file

### DIFF
--- a/eamena/eamena/settings.py
+++ b/eamena/eamena/settings.py
@@ -3,6 +3,10 @@ import inspect
 from arches_hip.settings import *
 from django.utils.translation import ugettext as _
 
+try:
+    from settings_local import GDAL_LIBRARY_PATH
+except ImportError:
+    pass
 
 PACKAGE_ROOT = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 PACKAGE_NAME = PACKAGE_ROOT.split(os.sep)[-1]


### PR DESCRIPTION
### Description of Change

For operating systems that need to have the GDAL library explicitly set, this can usually happen with the default import pattern that loads settings_local.py at the very end of settings.py. However, in this case an error is thrown because operations in the middle of settings.py seem to require that GDAL be accessible immediately.

This change attempts an import of the GDAL_LIBRARY_PATH variable at the beginning of settings.py, and if that import attempt fails (i.e. there is no settings_local.py or GDAL_LIBRARY_PATH is not defined because the OS doesn't require it) then no exception is raised.