### PR TITLE
update resource type icons re: #3, also bump fa version

### DIFF
--- a/eamena/eamena/settings.py
+++ b/eamena/eamena/settings.py
@@ -39,7 +39,7 @@ def RESOURCE_TYPE_CONFIGS():
         'HERITAGE_RESOURCE_GROUP.E27': {
             'resourcetypeid': 'HERITAGE_RESOURCE_GROUP.E27',
             'name': _('Heritage Place'),
-            'icon_class': 'fa fa-map-marker',
+            'icon_class': 'fa fa-stop',
             'default_page': 'summary',
             'default_description': _('No name available'),
             'description_node': _('NAME.E41'),
@@ -58,8 +58,8 @@ def RESOURCE_TYPE_CONFIGS():
         'HERITAGE_FEATURE.E24': {
             'resourcetypeid': 'HERITAGE_FEATURE.E24',
             'name': _('Heritage Feature'),
-            'icon_class': 'fa fa-university',
-            'default_page': 'summary',
+            'icon_class': 'fa fa-th-large',
+            'default_page': 'summary-feature',
             'default_description': _('No name available'),
             'description_node': _('NAME.E41'),
             'categories': [_('Resource')],
@@ -70,6 +70,25 @@ def RESOURCE_TYPE_CONFIGS():
             'fill_color': '#eedbad',
             'primary_name_lookup': {
                 'entity_type': 'EAMENA_ID.E42',
+                'lookup_value': 'Primary'
+            },
+            'sort_order': 2
+        },
+        'HERITAGE_COMPONENT.B2': {
+            'resourcetypeid': 'HERITAGE_COMPONENT.B2',
+            'name': _('Heritage Component'),
+            'icon_class': 'fa fa-th',
+            'default_page': 'summary-component',
+            'default_description': _('No name available'),
+            'description_node': _('NAME.E41'),
+            'categories': [_('Resource')],
+            'has_layer': True,
+            'on_map': True,
+            'marker_color': '#FFC53D',
+            'stroke_color': '#d9b562',
+            'fill_color': '#eedbad',
+            'primary_name_lookup': {
+                'entity_type': 'HERITAGE_COMPONENT_ID.E42',
                 'lookup_value': 'Primary'
             },
             'sort_order': 2

--- a/eamena/eamena/templates/base.htm
+++ b/eamena/eamena/templates/base.htm
@@ -20,7 +20,7 @@
 	{% block css %}
         <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.0/css/bootstrap.min.css">
         <link rel="stylesheet" href="{% static 'plugins/line-icons/line-icons.css' %}">
-        <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
         <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/octicons/2.1.2/octicons.min.css">
         <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/select2/3.5.0/select2-bootstrap.min.css" type="text/css">
         <link rel="stylesheet" href="{% static 'css/main.css' %}">


### PR DESCRIPTION
This addresses the suggestion I made in #3. Upgrading to fa v5 is more involved than really necessary for this effort (other icons throughout the app would need to be renamed, as far as I could tell), so I just took the opportunity to move to 4.7.

Note that this pull request also adds the new HERITAGE_COMPONENT.B2 feature type.