### PR TITLE
add resource instance graph logging to forms for debugging

### DIFF
--- a/arches/app/models/forms.py
+++ b/arches/app/models/forms.py
@@ -21,6 +21,7 @@ from django.utils import translation
 from arches.app.views.concept import get_preflabel_from_valueid
 from arches.app.models.entity import Entity
 from django.utils.translation import ugettext as _
+from django.conf import settings
 
 class ResourceForm(object):
     def __init__(self, resource):
@@ -31,6 +32,14 @@ class ResourceForm(object):
         self.icon = info['icon']
         self.resource = resource
         self.data = {}
+        
+        if resource.entityid and settings.DEBUG:
+            import os, json
+            from arches.app.search.search_engine_factory import SearchEngineFactory
+            se = SearchEngineFactory().create()
+            report_info = se.search(index='resource', id=resource.entityid)
+            with open(os.path.join(settings.PACKAGE_ROOT,'logs','current_graph.json'),'wb') as out:
+                json.dump(report_info['_source']['graph'],out,indent=1)
 
     @property
     def schema(self):


### PR DESCRIPTION
This PR would add a little bit of extra logging that is useful during development. If `settings.DEBUG`, then a file called `current_graph` will be created or overwritten in the existing logs directory. The contents of this file is the graph for the resource instance that is stored in ElasticSearch. For example:

```
{
 "COMPONENT_CLASSIFICATION_E17": [
  {
   "orderby": "", 
   "COMPONENT_ORIENTATION_E55": [
    {
     "COMPONENT_ORIENTATION_E55__label": "Neolithic (North Africa)", 
     "COMPONENT_ORIENTATION_E55__value": "2d9503e2-fc56-478d-863c-a77885a24d2d"
    }
   ]
  }, 
  {
   "COMPONENT_TYPE_E55": [
    {
     "COMPONENT_TYPE_E55__value": "b2b945dc-381e-476b-a214-4b08e4a25277", 
     "COMPONENT_TYPE_E55__label": "Door/entrance added"
    }
   ], 
   "orderby": ""
  }
 ], 
 "HERITAGE_COMPONENT_ID_E42": [
  {
   "HERITAGE_COMPONENT_ID_E42__value": "HERITAGE-0000017", 
   "HERITAGE_COMPONENT_ID_E42__label": "HERITAGE-0000017"
  }
 ]
}
```

This is a non-breaking enhancement that can be expanded upon or moved to other parts of the app at a later date. For example, seeing this graph is exceptionally useful when working on creating the resource reports.
