### PR TITLE
create modification form for E24, use new form formatting

### DIFF
--- a/eamena/eamena/media/css/new-form-style.css
+++ b/eamena/eamena/media/css/new-form-style.css
@@ -1,0 +1,89 @@
+/* Input Form */
+.form-full-content {
+    margin: 10px;
+}
+
+.form-full-content dl {
+    margin-bottom: 10px !important;
+}
+
+.form-section-header {
+    width: 100%;
+    text-align:left;
+    border-bottom: 1px solid #eee; 
+    line-height: 0.1em;
+    margin: 20px 0px 15px; 
+    font-size: 18px;
+    font-weight: 500;
+}
+
+.form-section-header span {
+    background: #fff;
+    padding-right: 10px;
+}
+
+.form-section-subheader {
+    width: 100%;
+    text-align:center;
+    border-bottom: 1px solid #eee; 
+    line-height: 0.1em;
+    margin: 20px 0px 15px; 
+    font-size: 16px;
+    font-weight: 500;
+}
+
+.form-section-subheader span {
+    background: #fff;
+    padding-right: 10px;
+    padding-left: 10px;
+}
+
+.form-group {
+    width: 100%;
+    margin-bottom: 0px !important;
+}
+
+.form-section-input {
+    padding-left:0px !important;
+    padding-right:0px !important;
+}
+
+.filler-text-inline {
+    height: 21px;
+}
+
+.filler-text-block {
+    height: 24px;
+}
+
+.arches-crud-child-section-new {
+    margin-top: 5px;
+}
+
+@media screen and (min-width: 768px) {
+    .add-padding-right {
+        padding-right: 5px !important;
+    }
+}
+
+@media screen and (min-width: 768px) {
+    .add-button-column {
+        padding-left: 0px !important;
+    }
+}
+
+@media screen and (max-width: 768px) {
+    .add-margin-top {
+        margin-top: 5px !important;
+    }
+}
+
+.arches-select2-crud-form  {
+    width: 100%;
+}
+
+.arches-form-input {
+    width: 100% !important;
+}
+
+/* Input Form end */

--- a/eamena/eamena/media/js/views/forms/modification.js
+++ b/eamena/eamena/media/js/views/forms/modification.js
@@ -22,7 +22,7 @@ define(['jquery',
                 this.addBranchList(new BranchList({
                     el: this.$el.find('#modification-section')[0],
                     data: this.data,
-                    dataKey: 'MODIFACATION.E11',
+                    dataKey: 'MODIFICATION.E11',
                     validateBranch: function (nodes) {
                         var ck0 = this.validateHasValues(nodes)
                         var ck1 = vt.isValidDate(nodes,'MODIFICATION_DATE.E49');

--- a/eamena/eamena/media/js/views/forms/modification.js
+++ b/eamena/eamena/media/js/views/forms/modification.js
@@ -1,0 +1,35 @@
+define(['jquery', 
+    'summernote',
+    'underscore', 
+    'knockout-mapping', 
+    'views/forms/base', 
+    'views/forms/sections/branch-list',
+    'views/forms/sections/validation',
+    'bootstrap-datetimepicker',
+    ], 
+    function ($, summernote, _, koMapping, BaseForm, BranchList, ValidationTools) {
+        var vt = new ValidationTools;
+        return BaseForm.extend({
+            initialize: function() {
+                BaseForm.prototype.initialize.apply(this);
+                var self = this;
+                // console.log("self.data", self.data);
+                var date_picker = $('.datetimepicker').datetimepicker({pickTime: false});
+                date_picker.on('dp.change', function(evt){
+                    $(this).find('input').trigger('change'); 
+                });
+
+                this.addBranchList(new BranchList({
+                    el: this.$el.find('#modification-section')[0],
+                    data: this.data,
+                    dataKey: 'MODIFACATION.E11',
+                    validateBranch: function (nodes) {
+                        var ck0 = this.validateHasValues(nodes)
+                        var ck1 = vt.isValidDate(nodes,'MODIFICATION_DATE.E49');
+                        return ck0 && ck1;
+                    }
+                }));
+            }
+        });
+    }
+);

--- a/eamena/eamena/models/forms.py
+++ b/eamena/eamena/models/forms.py
@@ -115,7 +115,30 @@ class SummaryForm(ResourceForm):
                 }
             }
 
+class ModificationForm(ResourceForm):
+    @staticmethod
+    def get_info():
+        return {
+            'id': 'modification',
+            'icon': 'fa-plus',
+            'name': _('Modifications'),
+            'class': ModificationForm
+        }
 
+    def update(self, data, files):
+        self.update_nodes('MODIFACATION.E11', data)
+        return
+
+    def load(self, lang):
+        if self.resource:
+            self.data['MODIFACATION.E11'] = {
+                'branch_lists': self.get_nodes('MODIFACATION.E11'),
+                'domains': {
+                    'CONSTRUCTION_TECHNIQUE_TYPE.E55' : Concept().get_e55_domain('CONSTRUCTION_TECHNIQUE_TYPE.E55'),
+                    'MODIFICATION_TYPE.E55' : Concept().get_e55_domain('MODIFICATION_TYPE.E55'),
+                    'CONSTRUCTION_MATERIAL.E57' : Concept().get_e55_domain('CONSTRUCTION_MATERIAL.E57')
+                }
+            }
 
 # --- Assessment  Summary -> AssessmentSummaryForm ------------------------------------------
 class AssessmentSummaryForm(ResourceForm):

--- a/eamena/eamena/models/forms.py
+++ b/eamena/eamena/models/forms.py
@@ -126,13 +126,13 @@ class ModificationForm(ResourceForm):
         }
 
     def update(self, data, files):
-        self.update_nodes('MODIFACATION.E11', data)
+        self.update_nodes('MODIFICATION.E11', data)
         return
 
     def load(self, lang):
         if self.resource:
-            self.data['MODIFACATION.E11'] = {
-                'branch_lists': self.get_nodes('MODIFACATION.E11'),
+            self.data['MODIFICATION.E11'] = {
+                'branch_lists': self.get_nodes('MODIFICATION.E11'),
                 'domains': {
                     'CONSTRUCTION_TECHNIQUE_TYPE.E55' : Concept().get_e55_domain('CONSTRUCTION_TECHNIQUE_TYPE.E55'),
                     'MODIFICATION_TYPE.E55' : Concept().get_e55_domain('MODIFICATION_TYPE.E55'),

--- a/eamena/eamena/models/resource.py
+++ b/eamena/eamena/models/resource.py
@@ -69,8 +69,12 @@ class Resource(ArchesResource):
                 # forms.TestWizForm.get_info(),
         
             ]
-
-
+            
+        elif self.entitytypeid == 'HERITAGE_FEATURE.E24':
+            description_group['forms'][:0] = [
+                forms.ModificationForm.get_info(),
+            ]
+            
         elif self.entitytypeid == 'ACTIVITY.E7':
             description_group['forms'][:0] = [
                 forms.ActivitySummaryForm.get_info(),

--- a/eamena/eamena/templates/base.htm
+++ b/eamena/eamena/templates/base.htm
@@ -31,6 +31,7 @@
         <link rel="stylesheet" href="{% static 'plugins/openlayers/ol.css' %}">
         <link rel="stylesheet" href="{% static 'css/arches.css' %}">
         <link rel="stylesheet" href="{% static 'css/package.css' %}">
+        <link rel="stylesheet" href="{% static 'css/new-form-style.css' %}">
     {% endblock css%}
 
 </head> 

--- a/eamena/eamena/templates/views/forms/modification.htm
+++ b/eamena/eamena/templates/views/forms/modification.htm
@@ -1,0 +1,92 @@
+{% extends "views/forms/base.htm" %}
+{% load i18n %}
+
+
+
+{% block form_content %}
+<div class="form-full-content">
+    <div class="row">
+        <div class="col-xs-12 margin-bottom-10">
+            <div class="form-section-header"><span>{% trans "Modifications" %}</span></div>
+        </div>
+    </div>
+    <div id="modification-section">
+        <div class="row">
+            <div class="col-xs-12 col-sm-9">
+                <div class="col-xs-6 form-section-input add-padding-right">
+                    <div class="form-group">
+                        <input class="select2 arches-select2-crud-form" data-bind="select2: {value: getEditedNode('MODIFICATION_TYPE.E55', 'value'), placeholder: '{% trans 'Modification Type' %}', dataKey: 'MODIFICATION_TYPE.E55'}"></input>
+                    </div>
+                </div>
+                <div class="col-xs-6 form-section-input">
+                    <div class="form-group datetimepicker">
+                        <div class="input-group">
+                            <input type="text" name="mydate" id="date-from" placeholder='{% trans "date (yyyy-mm-dd)" %}' class="form-control datepicker" data-date-format="YYYY-MM-DD" data-bind="{value: getEditedNode('MODIFICATION_DATE.E49', 'value')} ">
+                            <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-xs-12 form-section-subheader">
+                    <span>{% trans "Description of Modification" %}</span>
+                </div>
+                <div class="col-xs-12 form-section-input margin-top-5">
+                    <div class="form-group">
+                        <div class="summernote" data-bind="summernote: {value: getEditedNode('MODIFICATION_DESCRIPTION.E62', 'value'), options:{}}"></div>
+                    </div>
+                </div>
+                <div class="col-xs-12 form-section-subheader">
+                    <span>{% trans "Construction" %}</span>
+                </div>
+                <div class="col-xs-6 form-section-input margin-top-5 add-padding-right">
+                    <div class="form-group">
+                        <input class="select2 arches-select2-crud-form" data-bind="select2: {value: getEditedNode('CONSTRUCTION_TECHNIQUE_TYPE.E55', 'value'), placeholder: '{% trans 'Construction Technique Type' %}', dataKey: 'CONSTRUCTION_TECHNIQUE_TYPE.E55'}"></input>
+                    </div>
+                </div>
+                <div class="col-xs-6 form-section-input margin-top-5">
+                    <div class="form-group">
+                        <input class="select2 arches-select2-crud-form" data-bind="select2: {value: getEditedNode('CONSTRUCTION_MATERIAL.E57', 'value'), placeholder: '{% trans 'Construction Material' %}', dataKey: 'CONSTRUCTION_MATERIAL.E57'}"></input>
+                    </div>
+                </div>
+                <div class="col-xs-12 form-section-input margin-top-5">
+                    <input class="form-control arches-form-input" placeholder='{% trans "Construction Note" %}' data-bind='value: getEditedNode("CONSTRUCTION_NOTE.E62", "value")'></input>
+                </div>
+                
+            </div>
+            <div class="col-xs-12 col-sm-3 add-button-column add-margin-top">
+                {% include 'views/components/add-item-button.htm' %}
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-xs-12 col-sm-9">
+                <div class="alert alert-danger branch-invalid-alert" role="alert" style="display:none;">{% trans "All values must be populated, and dates must be valid (YYYY-MM-DD)." %}</div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-xs-12">
+                <div class="arches-crud-child-section-new">
+                    <dl>
+                        <dd class="margin-left-5" style="display: none;" data-bind="visible: true">
+                            <div data-bind="visible: getBranchLists().length == 0" class="txt-color-blue filler-text-block nr"></div>
+                            <div data-bind='foreach: getBranchLists()'>
+                                <div class="arches-crud-record" style="display:block;">
+                                    <a href="javascript:void(0)" title="remove"><i data-bind="click: $parent.deleteItem.bind($parent)" class="arches-CRUD-delete fa fa-times-circle"></i></a>
+                                    <a href="javascript:void(0)" class="arches-CRUD-child arches-CRUD-edit" title="{% trans 'edit' %}" data-bind='click: $parent.editItem.bind($parent)'>
+                                        <span data-bind="text: nodes.get('MODIFICATION_TYPE.E55', 'label')"></span>
+                                    </a><span class="text-muted" data-bind="html: nodes.get('MODIFICATION_DATE.E49', 'label').slice(0,10)"></span><br>
+                                    <span data-bind="html: nodes.get('MODIFICATION_DESCRIPTION.E62', 'value')"></span><br>
+                                    <span data-bind="html: nodes.get('CONSTRUCTION_TECHNIQUE_TYPE.E55', 'label')"></span><span class="text-muted">&nbsp;({% trans "Construction Technique" %})</span><br>
+                                    <span data-bind="html: nodes.get('CONSTRUCTION_MATERIAL.E57', 'label')"></span><span class="text-muted">&nbsp;({% trans "Construction Material" %})</span><br>
+                                    <span data-bind="html: nodes.get('CONSTRUCTION_NOTE.E62', 'value')"></span><span class="text-muted">&nbsp;({% trans "Construction Note" %})</span>
+                                </div>
+                            </div>
+                        </dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+        
+    </div>
+</div>
+
+{% include 'views/forms/sections/SaveEditsFooter.htm' %}
+{% endblock form_content %}


### PR DESCRIPTION
### Description of Change
This PR creates a single new form for the E24 resource type, Heritage Feature. This is a brand new form (not copy/pasted from existing forms in the EAMENA code base), so I used a format system that I developed for the AFRH Arches implementation, a markup system that makes more use of bootstrap classes instead of style added at the DOM-element. A new stylesheet was added as well, which, in the future, could be merged into the existing `package.css`.

Note that you'll be able to view this form at http://localhost:8000/resources/HERITAGE_FEATURE.E24/modification/.

Also, this PR must be merged into a branch into which PR #6 has already been merged. Otherwise, you'll get an error when trying to view the form. If necessary, I can add a commit here to make it work without #6.
