### PR TITLE
Eamena location form zoom and resource layer

### DIFF
--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 '''
 
 import uuid
+import json
 from datetime import datetime
 from django.conf import settings
 from django.contrib.gis.geos import fromstr
@@ -25,10 +26,12 @@ from django.db.models import Q
 from arches.app.models.entity import Entity
 from arches.app.models.concept import Concept
 from arches.app.search.search_engine_factory import SearchEngineFactory
+from arches.app.search.elasticsearch_dsl_builder import Bool, Match, Query
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from django.utils.translation import ugettext as _
 from django.forms.models import model_to_dict
 from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.gdal import SpatialReference, CoordTransform
 
 
 class Resource(Entity):
@@ -1021,3 +1024,58 @@ class Resource(Entity):
             'id': None,
             'data': None
         }
+        
+    def get_geom(self,buffer_distance=''):
+        ''' Returns a geojson object representing the resource's geometry,
+        as well as a couple useful properties.
+        
+        Technically, a FeatureCollection is returned. This is in antici-
+        pation of augmenting this method to return, for example, the 
+        geometries of nearby features as well.
+        
+        If the Resource has not yet been saved (has no UUID entityid),
+        or does not have a geometry yet, None is returned.
+        '''
+        
+        if not self.entityid:
+            return None
+        
+        ## use entity id to find this resource in ES
+        se = SearchEngineFactory().create()
+        query = Query(se)
+        bool = Bool()
+        bool.must(Match(field='_all', query=self.entityid))
+        query.add_query(bool)
+        results = query.search(index='resource')
+        geomjson = results['hits']['hits'][0]['_source']['geometry']
+        if not geomjson:
+            return None
+            
+        ## taking care of the transformation here is easier/more efficient
+        ## than on the front-end, however, elsewhere in the app transformations
+        ## are handled on the front-end.
+        geosgeom = GEOSGeometry(json.dumps(geomjson),srid=4326)
+        trans = CoordTransform(SpatialReference(4326), SpatialReference(3857))
+        geosgeom.transform(trans)
+        
+        fulljson = {
+            'type':'FeatureCollection',
+            'crs': {
+              'type': 'name',
+              'properties': {
+                'name': 'EPSG:3857'
+              }
+            },
+            'features': [
+                {
+                    'type':'Feature',
+                    'geometry':json.loads(geosgeom.geojson),
+                    'properties': {
+                        'name':self.get_primary_name(),
+                        'resource_type':self.entitytypeid
+                    }
+                }
+            ]
+        }
+
+        return fulljson

--- a/arches/app/views/resources.py
+++ b/arches/app/views/resources.py
@@ -100,7 +100,8 @@ def resource_manager(request, resourcetypeid='', form_id='default', resourceid='
                     'min_date': min_max_dates['val__min'].year if min_max_dates['val__min'] != None else 0,
                     'max_date': min_max_dates['val__max'].year if min_max_dates['val__min'] != None else 1,
                     'timefilterdata': JSONSerializer().serialize(Concept.get_time_filter_data()),
-                    'resource_icon': settings.RESOURCE_TYPE_CONFIGS()[resourcetypeid]['icon_class']
+                    'resource_icon': settings.RESOURCE_TYPE_CONFIGS()[resourcetypeid]['icon_class'],
+                    'resource_geom': JSONSerializer().serialize(resource.get_geom())
                 },
                 context_instance=RequestContext(request))
         else:

--- a/eamena/eamena/media/js/views/forms/man-made-component.js
+++ b/eamena/eamena/media/js/views/forms/man-made-component.js
@@ -20,7 +20,8 @@ define(['jquery',
             var locationBranchList = new LocationBranchList({
                 el: this.$el.find('#heritage-location')[0],
                 data: this.data,
-                dataKey: 'SPATIAL_COORDINATES.E47'
+                dataKey: 'SPATIAL_COORDINATES.E47',
+                addParentGeom: true
             });
             this.addBranchList(locationBranchList);
 

--- a/eamena/eamena/media/js/views/forms/man-made.js
+++ b/eamena/eamena/media/js/views/forms/man-made.js
@@ -20,7 +20,8 @@ define(['jquery',
                 var locationBranchList = new LocationBranchList({
                     el: this.$el.find('#heritage-location')[0],
                     data: this.data,
-                    dataKey: 'GEOMETRIC_PLACE_EXPRESSION.SP5'
+                    dataKey: 'GEOMETRIC_PLACE_EXPRESSION.SP5',
+                    addParentGeom: true
                 });
                 this.addBranchList(locationBranchList);
     

--- a/eamena/eamena/media/js/views/forms/sections/location-branch-list.js
+++ b/eamena/eamena/media/js/views/forms/sections/location-branch-list.js
@@ -133,21 +133,36 @@ define([
 
             var style = function (feature) {
                 var editing = feature.get('editing');
+                // change the new feature color to green if this is a map to
+                // which existing geometries are being added.
+                console.log(self.addParentGeom)
+                
+                if (self.addParentGeom) {
+                    var colors = {
+                        full:'rgba(101, 191, 11, 100)',
+                        trans: 'rgba(101, 191, 11, 0)'
+                    }
+                } else {
+                    var colors = {
+                        full:'rgba(179, 0, 0, 100)',
+                        trans: 'rgba(179, 0, 0, 0)'
+                    }
+                }
                 return [new ol.style.Style({
                     fill: new ol.style.Fill({
-                        color: 'rgba(92, 184, 92, 0)'
+                        color: colors['trans']
                     }),
                     stroke: new ol.style.Stroke({
-                        color: '#b30000',
+                        color: colors['full'],
                         width: editing ? 4 : 3
                     }),
                     image: new ol.style.Circle({
                         radius: editing ? 9 : 7,
                         fill: new ol.style.Fill({
-                            color: 'rgba(92, 184, 92, 0)'
+                            color: colors['trans']
                         }),
                         stroke: new ol.style.Stroke({
-                            color: '#b30000',
+                            color: colors['full'],
                             width: editing ? 4 : 3
                         })
                     })
@@ -221,7 +236,7 @@ define([
             this.on('formloaded', function(){
                 map.map.updateSize()
             });
-
+            
             var draw = null;
 
             self.$el.find(".geometry-btn").click(function (){ 
@@ -375,6 +390,11 @@ define([
               }
             });
             map.map.addInteraction(modify);
+
+            // add overlay of this resource's geometry if desired
+            if (self.addParentGeom) {
+                map.addResourceGeomLayer();
+            }
         },
         getBranchLists: function() {    
             var self = this;
@@ -394,6 +414,7 @@ define([
                 branch.editing(false);
             }
             return branch;
-        },
+        }
+        
     });
 });

--- a/eamena/eamena/media/js/views/map.js
+++ b/eamena/eamena/media/js/views/map.js
@@ -152,7 +152,7 @@ define([
             var format = ol.coordinate.createStringXY(4);
             var overFeature = this.map.forEachFeatureAtPixel(pixels, function (feature, layer) {
                 //return the first actual marker, but ignore any other geometries under the cursor (most likely )
-                if(feature.get('arches_marker') || feature.get('arches_cluster')) {
+                if(feature.get('arches_marker') || feature.get('arches_cluster') || feature.get('name')) {
                     return feature;
                 }
             });
@@ -162,8 +162,12 @@ define([
                 this.trigger('mousePositionChanged', format(coords), pixels, overFeature);
                 if ($('#tooltip').length) {
                     $("#tooltip").show();
-                    $("#tooltip").html("<label>" + coords[1].toFixed(4) + "° N</label>&nbsp;<label>" + coords[0].toFixed(4) + " ° E</label>");
-            	    $("#tooltip").css({position:"absolute", left:xpos+15,top:ypos});
+                    var msg_content = coords[1].toFixed(4) + "° N&nbsp;&nbsp;" + coords[0].toFixed(4) + " ° E"
+                    if (overFeature && overFeature.get('name')) {
+                        msg_content += "<br><span style='color:rgb(179, 0, 0);'>"+overFeature.get('name')+"</span>"
+                    };
+                    $("#tooltip").html("<label>"+msg_content+"</label>");
+                    $("#tooltip").css({position:"absolute", left:xpos+15,top:ypos});
                 }
             } else {
                 this.trigger('mousePositionChanged', '');

--- a/eamena/eamena/media/js/views/map.js
+++ b/eamena/eamena/media/js/views/map.js
@@ -176,6 +176,47 @@ define([
             if ($('#tooltip').length) {
                  $("#tooltip").hide();
             }
+        },
+        
+        addResourceGeomLayer: function(){
+
+            var geojson = $('#resource_geom').val();
+            var format = new ol.format.GeoJSON;
+
+            var green_style = function (feature) {
+                return [new ol.style.Style({
+                    fill: new ol.style.Fill({
+                        color: 'rgba(179, 0, 0, 0)'
+                    }),
+                    stroke: new ol.style.Stroke({
+                        color: 'rgba(179, 0, 0, 100)',
+                        width: 3
+                    }),
+                    image: new ol.style.Circle({
+                        radius: 7,
+                        fill: new ol.style.Fill({
+                            color: 'rgba(179, 0, 0, 0)'
+                        }),
+                        stroke: new ol.style.Stroke({
+                            color: 'rgba(179, 0, 0, 100)',
+                            width: 3
+                        })
+                    })
+                })];
+            }
+            
+            var source = new ol.source.Vector({
+                features: format.readFeatures(geojson)
+            })
+            
+            var newlayer = new ol.layer.Vector({
+                title: 'Existing Resource Geometries',
+                source: source,
+                style: green_style
+            })
+            
+            this.map.addLayer(newlayer);
+            this.map.getView().fit(source.getExtent(), ([500,500]));
         }
     });
 });

--- a/eamena/eamena/templates/resource-manager.htm
+++ b/eamena/eamena/templates/resource-manager.htm
@@ -188,5 +188,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 <div style="display:none;" id="form-data">
     <input type="hidden" id="form-id" value="{{form_id}}">
     <input type="hidden" id="resourcetypeid" value="{{resourcetypeid}}">
+    <input type="hidden" id="resource_geom" value="{{resource_geom}}">
 </div>
 {% endblock %}


### PR DESCRIPTION
Task 7: Display existing resource in Location tabs.

When looking at the related resource creation wizards (the form for E24 Features that is accessed through the E27 interface and the form for B2 Components that is accessed through the E24 interface), the UX should be improved in the following way (using the E27/E24 case as an example):

- If geometry has been saved for the E27 Place, the view of the map in the E24 Feature wizard location tab should be automatically zoomed to this geometry.
- This existing E27 geometry should also be shown on the map, to make it easy for the user to place the new E24 geometry inside of it.

To achieve these things, this pull request adds the following:

- a new method on the Resource class that returns a GeoJSON object of any geometries for the resource.
- an new function on views/map.js that will add this GeoJSON to that view model's map when called
- an integration of this new function into the appropriate forms
- a mouseover hint that shows the id of the existing resource geometry that is on the map

Notes:

I decided to follow the existing pattern of passing context variables into the resource-manager template and retrieving them in the view model, as opposed to creating a brand new view and calling that with an ajax request from within the view mode. This allows for a discrete but meaningful addition to the core Arches codebase. If a view is desired down the road, this same Resource().get_geom() method will be used anyway.

I modified the views/map view model, instead adding to its downstream instantiation in views/forms/sections/location-branch-list. This allows the new function to be used outside of the resource manager context if that's ever necessary.

I also changed the color of the geometry to make editing easier. In the normal location forms the geometry is red, just like before. I used this same red in the new resource overlay in the wizard form tabs, and changed the editing color to green. This is meant to make it clear to the user that red indicates the E27 (for example) resource no matter which form they see it in, and the green is for the new "embedded" resource.