### PR TITLE
Fix to allow mutiple file and image uploads at once

### DIFF
--- a/eamena/eamena/models/forms.py
+++ b/eamena/eamena/models/forms.py
@@ -497,6 +497,8 @@ class RelatedFilesForm(ResourceForm):
                 filedict[f.name] = f
 
         for newfile in data.get('new-files', []):
+            if newfile['id'] not in filedict:
+                continue
             resource = Resource()
             resource.entitytypeid = 'INFORMATION_RESOURCE.E73'
             resource.set_entity_value('INFORMATION_RESOURCE_TYPE.E55', newfile['title_type']['value'])


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->
<!--- You can erase any part of this template that is not applicable to your Issue. -->

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Although this doesn't do anything about the need to refresh the page without caching, to get multiple files to save is remarkably simple - I added a conditional so the Information resource is only created when the loop is running using that specific uploaded file. 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
[eamena_v3/86](https://github.com/azerbini/eamena_v3/issues/86)

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
