### PR TITLE
handle UUIDs in r2r relationship creation, re #65

### DIFF
--- a/eamena/eamena/models/forms.py
+++ b/eamena/eamena/models/forms.py
@@ -60,6 +60,19 @@ def add_actor( observed_field, actor_field, data, user):
         
     return data
 
+def handle_relationship_object(object):
+    """helper method to properly serialize relationship objects to prepare them
+    for elasticsearch indexing."""
+
+    mdict = model_to_dict(object)
+    ret = {}
+    for k, v in mdict.iteritems():
+        if isinstance(v, uuid.UUID):
+            v = str(v)
+        ret[k] = v
+
+    return ret
+
 def datetime_nodes_to_dates(branch_list):
     for branch in branch_list:
         for node in branch['nodes']:
@@ -669,7 +682,8 @@ class ManMadeForm(ResourceForm):
             except:
                 continue
         relationship = self.resource.create_resource_relationship(resource.entityid, relationship_type_id=relation_id)
-        se.index_data(index='resource_relations', doc_type='all', body=model_to_dict(relationship), idfield='resourcexid')
+        relationship_doc = handle_relationship_object(relationship)
+        se.index_data(index='resource_relations', doc_type='all', body=relationship_doc, idfield='resourcexid')
 
         return
 
@@ -787,7 +801,8 @@ class ManMadeComponentForm(ResourceForm):
             except:
                 continue
         relationship = self.resource.create_resource_relationship(resource.entityid, relationship_type_id=relation_id)
-        se.index_data(index='resource_relations', doc_type='all', body=model_to_dict(relationship), idfield='resourcexid')
+        relationship_doc = handle_relationship_object(relationship)
+        se.index_data(index='resource_relations', doc_type='all', body=relationship_doc, idfield='resourcexid')
 
         return
 


### PR DESCRIPTION
Signed-off-by: adam cox <mr.adamcox@gmail.com>

## Description of Change
Adds a helper function that handles UUID objects in serialized ResourceRelation objects.

@azerbini I'd like to get your feedback on this, as this fix works well, but I'm unsure of why it is needed now, but wasn't earlier. Also, is this something that should be cherry-picked into the eamena-migration-branch?

### Issues Solved
#65 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments
Note that the ticket this is meant to address only mentions the scenario where an E24 resource is made from within an E27. However, I found that making a B2 from within an E24 also resulted in the same error, so I address that here as well.
