### PR TITLE
refactor default user creation to a csv file

### DIFF
--- a/arches/install/initial_users.csv
+++ b/arches/install/initial_users.csv
@@ -1,0 +1,2 @@
+username,firstname,lastname,email,password,superuser,staff,groups
+admin,,,,admin,yes,yes,edit;read

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -142,6 +142,8 @@ APP_NAME = 'Arches v3.0'
 
 ROOT_DIR = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 
+INITIAL_USERS_CONFIG = os.path.join(ROOT_DIR,"install","initial_users.csv")
+
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
 )


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
<!--- You can erase any part of this template that is not applicable to your Issue. -->

### Description of Change
During packages -o install, remove the `admin` user that Arches creates by default, and replace with a user (also named admin) from a CSV file that is referenced in settings. This sets the foundation for the automatic creation of default users that are not the `admin/admin` user by allowing users to set a new path to their own CSV file, in settings.py or (ideally) settings_local.py.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
