### PR TITLE
Resource view now returns a url when accessed through ajax

### DIFF
--- a/arches/app/views/resources.py
+++ b/arches/app/views/resources.py
@@ -34,6 +34,7 @@ from django.http import HttpResponseNotFound
 from django.contrib.gis.geos import GEOSGeometry
 from django.db.models import Max, Min
 from django.contrib.auth.decorators import login_required, user_passes_test
+from django.core.urlresolvers import reverse
 
 
 def report(request, resourceid):
@@ -75,6 +76,10 @@ def resource_manager(request, resourcetypeid='', form_id='default', resourceid='
             resource.save(user=request.user)
             resource.index()
             resourceid = resource.entityid
+
+            if request.is_ajax():
+                return JSONResponse({"url": reverse('resource_manager', kwargs={
+                    'resourcetypeid': resourcetypeid, 'form_id': form_id,'resourceid': resourceid})})
 
             return redirect('resource_manager', resourcetypeid=resourcetypeid, form_id=form_id, resourceid=resourceid)
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
<!--- You can erase any part of this template that is not applicable to your Issue. -->

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
To fix the issue with dropzones loading the wrong url, the correct url is now passed back if the request is ajax. 

Must be merged at the same time as the eamena-northafrica-app PR.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
