### PR TITLE
don't exclude sortorder values from the domain list

### DIFF
--- a/arches/app/models/concept.py
+++ b/arches/app/models/concept.py
@@ -719,6 +719,12 @@ class Concept(object):
                 
         for row in rows: # Looks for concepts which have multiple-language labels, including the target language, and builds an index of those rows
             rec = dict(zip(column_names, row))
+
+            # need to retain the sortorder values, even if they don't have the correct language
+            # associated with them.
+            if rec['vtype'] == "sortorder":
+                continue
+
             if str(rec['languageid']).lower() != language:
                 for concept in list_of_good_concepts:
                     if rec['conceptpath'][-37:-1] == concept:  #Retrieves the bottom conceptid in the conceptpath


### PR DESCRIPTION


<!--- Provide a general summary of the Pull Request in the Title above -->
<!--- You can erase any part of this template that is not applicable to your Issue. -->

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Ticket #125 described a problem of sortorder not being honored in dropdown lists when the site is in Arabic. This is a tiny change that addresses that.

The sortorder values had been conflated with rows that also contained a language definition of en-US, thus they were ignored by a filtering mechanism that was meant to only show Arabic labels.

The problem should be fixed now.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
